### PR TITLE
Add Title Format property to control how the title on the button is formatted

### DIFF
--- a/Clockify/PluginSettings.cs
+++ b/Clockify/PluginSettings.cs
@@ -19,6 +19,9 @@ namespace Clockify
         [JsonProperty(PropertyName = "timerName")]
         public string TimerName { get; set; } = string.Empty;
         
+        [JsonProperty(PropertyName = "titleFormat")]
+        public string TitleFormat { get; set; } = "{projectName}:\n{taskName}\n{timer}";
+
         [JsonProperty(PropertyName = "serverUrl")]
         public string ServerUrl { get; set; } = "https://api.clockify.me/api/v1";
     }

--- a/Clockify/PluginSettings.cs
+++ b/Clockify/PluginSettings.cs
@@ -17,7 +17,7 @@ namespace Clockify
         public string TaskName { get; set; } = string.Empty;
 
         [JsonProperty(PropertyName = "timerName")]
-        public string TimeName { get; set; } = string.Empty;
+        public string TimerName { get; set; } = string.Empty;
         
         [JsonProperty(PropertyName = "serverUrl")]
         public string ServerUrl { get; set; } = "https://api.clockify.me/api/v1";

--- a/Clockify/ToggleAction.cs
+++ b/Clockify/ToggleAction.cs
@@ -46,7 +46,7 @@ namespace Clockify
 
             if (_clockifyContext.IsValid())
             {
-                await _clockifyContext.ToggleTimerAsync(_settings.WorkspaceName, _settings.ProjectName, _settings.TaskName, _settings.TimeName);
+                await _clockifyContext.ToggleTimerAsync(_settings.WorkspaceName, _settings.ProjectName, _settings.TaskName, _settings.TimerName);
             }
             else
             {
@@ -58,7 +58,7 @@ namespace Clockify
         {
             if (_clockifyContext.IsValid())
             {
-                var timer = await _clockifyContext.GetRunningTimerAsync(_settings.WorkspaceName, _settings.ProjectName, _settings.TimeName);
+                var timer = await _clockifyContext.GetRunningTimerAsync(_settings.WorkspaceName, _settings.ProjectName, _settings.TimerName);
                 var timerText = CreateTimerText();
 
                 if (timer?.TimeInterval.Start != null)

--- a/PropertyInspector/PluginActionPI.html
+++ b/PropertyInspector/PluginActionPI.html
@@ -35,7 +35,7 @@
             <div class="sdpi-item">
                 <div class="sdpi-item-label">Title Format</div>
                 <div class="sdpi-item-value textarea">
-                    <textarea type="textarea" maxlength="100" id="titleFormat">{projectName}:
+                    <textarea class="sdpi-item-value sdProperty" id="titleFormat" type="textarea" maxlength="100" oninput="setSettings()">{projectName}:
 {taskName}
 {timer}</textarea>
                 </div>

--- a/PropertyInspector/PluginActionPI.html
+++ b/PropertyInspector/PluginActionPI.html
@@ -32,17 +32,22 @@
                 <div class="sdpi-item-label">Timer Name</div>
                 <input class="sdpi-item-value sdProperty" id="timerName" value="" placeholder="Enter the name of the Timer" oninput="setSettings()">
             </div>
-            <div class="sdpi-item">
-                <div class="sdpi-item-label">Title Format</div>
-                <div class="sdpi-item-value textarea">
-                    <textarea class="sdpi-item-value sdProperty" id="titleFormat" type="textarea" maxlength="100" oninput="setSettings()">{projectName}:
+            <div type="group" class="sdpi-item" id="advanced">
+                <div class="sdpi-item-label">Advanced</div>
+                <div class="sdpi-item-group" id="messagegroup_items">
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Title Format</div>
+                        <div class="sdpi-item-value textarea">
+                            <textarea class="sdpi-item-value sdProperty" id="titleFormat" type="textarea" maxlength="100" oninput="setSettings()">{projectName}:
 {taskName}
 {timer}</textarea>
+                        </div>
+                    </div>
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Server Url</div>
+                        <input class="sdpi-item-value sdProperty" id="serverUrl" value="https://api.clockify.me/api/v1" placeholder="Enter the ULR of the Server" oninput="setSettings()" required>
+                    </div>
                 </div>
-            </div>
-            <div class="sdpi-item">
-                <div class="sdpi-item-label">Server Url</div>
-                <input class="sdpi-item-value sdProperty" id="serverUrl" value="https://api.clockify.me/api/v1" placeholder="Enter the ULR of the Server" oninput="setSettings()" required>
             </div>
         </div>
     </body>

--- a/PropertyInspector/PluginActionPI.html
+++ b/PropertyInspector/PluginActionPI.html
@@ -34,7 +34,11 @@
             </div>
             <div class="sdpi-item">
                 <div class="sdpi-item-label">Title Format</div>
-                <input class="sdpi-item-value sdProperty" id="titleFormat" value="{projectName}:\n{taskName}\n{timer}" oninput="setSettings()">
+                <div class="sdpi-item-value textarea">
+                    <textarea type="textarea" maxlength="100" id="titleFormat">{projectName}:
+{taskName}
+{timer}</textarea>
+                </div>
             </div>
             <div class="sdpi-item">
                 <div class="sdpi-item-label">Server Url</div>

--- a/PropertyInspector/PluginActionPI.html
+++ b/PropertyInspector/PluginActionPI.html
@@ -33,6 +33,10 @@
                 <input class="sdpi-item-value sdProperty" id="timerName" value="" placeholder="Enter the name of the Timer" oninput="setSettings()">
             </div>
             <div class="sdpi-item">
+                <div class="sdpi-item-label">Title Format</div>
+                <input class="sdpi-item-value sdProperty" id="titleFormat" value="{projectName}:\n{taskName}\n{timer}" oninput="setSettings()">
+            </div>
+            <div class="sdpi-item">
                 <div class="sdpi-item-label">Server Url</div>
                 <input class="sdpi-item-value sdProperty" id="serverUrl" value="https://api.clockify.me/api/v1" placeholder="Enter the ULR of the Server" oninput="setSettings()" required>
             </div>

--- a/README.md
+++ b/README.md
@@ -10,13 +10,21 @@ Until the plugin is available in the [Stream Deck Store](https://apps.elgato.com
 
 ## Setup
 
-- **Title:** Override the title being set by the plugin, leave empty otherwise
-- **API Key:** *(required)* Provide your 48 characters long [Clockify API Key](https://clockify.me/user/settings), which is required for the plugin to work
-- **Workspace Name:** *(required)* Write the name of the workspace you want to run/track timers in
-- **Project Name:** *(optional)* Provide the name of an existing project to run/track a timer for
-- **Task Name:** *(optional)* Set the name of the project specific task
-- **Timer Name:** *(optional)* Specify a name for the timer you want to run/track
-- **Server Url:** *(required)* Change from the *default* URL to the API URL of your own/company instance
+- **Basic**
+  - **Title:** Override the title being set by the plugin, leave empty otherwise
+  - **API Key:** *(required)* Provide your 48 characters long [Clockify API Key](https://clockify.me/user/settings), which is required for the plugin to work
+  - **Workspace Name:** *(required)* Write the name of the workspace you want to run/track timers in
+  - **Project Name:** *(optional)* Provide the name of an existing project to run/track a timer for
+  - **Task Name:** *(optional)* Set the name of the project specific task
+  - **Timer Name:** *(optional)* Specify a name for the timer you want to run/track
+- **Advanced**
+  - **Title Format:** *(optional)* Specify the format for the title to be displayed on the button.
+    - This can include any of:
+      - {projectName} : The project name
+      - {taskName} : The task name 
+      - {timerName} : The timer name 
+      - {timer} : The current timer value when running. Blank when not running
+  - **Server Url:** *(required)* Change from the *default* URL to the API URL of your own/company instance
 
 https://user-images.githubusercontent.com/920861/132741561-6f9f3ff0-a920-408d-8279-579840ce0a6b.mp4
 


### PR DESCRIPTION
This PR adds a new multi-line text property, Title Format, which contains details of how the title should be formatted on the button.
It supports a number of different replacement values:
- {projectName} : The project name
- {taskName} : The task name 
- {timerName} : The timer name 
- {timer} : The current timer value when running. Blank when not running

It defaults to:
```
{projectName}:
{taskName}
{timer}
```
which is the original default title (if the timer name is not set).

With this setup, it's impossible to replicate the previous behavour exactly, where if `timerName` was set, this would replace the title.