### PR TITLE
Fix displaying of the warning on timer stops

### DIFF
--- a/Clockify/ClockifyContext.cs
+++ b/Clockify/ClockifyContext.cs
@@ -52,7 +52,7 @@ public class ClockifyContext
         if (runningTimer != null)
         {
             _logger.LogDebug("Toggle successful, timer has been stopped");
-            return false;
+            return true;
         }
 
         var workspace = _workspaces.SingleOrDefault(w => w.Name == _workspaceName);


### PR DESCRIPTION
Finally spotted the error that leads to the warning triangle showing briefly.

Fixes #28 