### PR TITLE
Add support for comma separated list of tags

### DIFF
--- a/Clockify/PluginSettings.cs
+++ b/Clockify/PluginSettings.cs
@@ -19,6 +19,9 @@ public class PluginSettings
     [JsonProperty(PropertyName = "timerName")]
     public string TimerName { get; set; } = string.Empty;
 
+    [JsonProperty(PropertyName = "tags")]
+    public string Tags { get; set; } = string.Empty;
+
     [JsonProperty(PropertyName = "clientName")]
     public string ClientName { get; set; } = string.Empty;
 

--- a/PropertyInspector/PluginActionPI.html
+++ b/PropertyInspector/PluginActionPI.html
@@ -33,6 +33,10 @@
                 <input class="sdpi-item-value sdProperty" id="timerName" value="" placeholder="Enter the name of the Timer" oninput="setSettings()">
             </div>
             <div class="sdpi-item">
+                <div class="sdpi-item-label">Tags</div>
+                <input class="sdpi-item-value sdProperty" id="tags" value="" placeholder="Comma separated list of Tags" oninput="setSettings()">
+            </div>
+            <div class="sdpi-item">
                 <div class="sdpi-item-label">Billable</div>
                 <div class="sdpi-item-value">
                     <div class="sdpi-item-child">


### PR DESCRIPTION
This closes #21 and adds the option to provide a comma separated list of tags

Currently, if a tag is added that doesn't exist already, it's silently ignored. The thinking here is, tags are managed per workspace, so chances are, you don't want to create random tags, instead they're carefully crafted at one point in time. Additionally, creating new tags from the plugin can easily lead to many typo-ed tags to be created. And finally, since tags can only be archived, you don't really want to create a lot of pointless tags.

But I'm open to discuss this point.

Give it a try with this build: https://github.com/eXpl0it3r/streamdeck-clockify/actions/runs/15835431507

![image](https://github.com/user-attachments/assets/a417e655-22dc-469c-bdaa-da0f90f2107f)

![image](https://github.com/user-attachments/assets/4b4503d0-5382-411d-8950-7d26af13987a)

![image](https://github.com/user-attachments/assets/e18fa358-73a7-4553-8a34-a32ee25581a4)

Note how `test3` doesn't exist and thus isn't tracked, while the other tags are tracked.