### PR TITLE
Use ClockifyClient as API client

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ end_of_line = lf
 indent_size = 4
 indent_style = space
 insert_final_newline = false
-max_line_length = 120
+max_line_length = 240
 tab_width = 4
 trim_trailing_whitespace = false
 

--- a/Clockify.csproj
+++ b/Clockify.csproj
@@ -40,7 +40,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NLog" Version="5.4.0" />
+    <PackageReference Include="NLog" Version="5.5.1" />
     <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="6.0.5.128" />
     <PackageReference Include="streamdeck-client-csharp" Version="4.3.0" />
     <PackageReference Include="StreamDeck-Tools" Version="6.2.0" />

--- a/Clockify.csproj
+++ b/Clockify.csproj
@@ -34,7 +34,7 @@
     <PublishDir>bin\Publish\dev.duerrenberger.clockify.sdPlugin\</PublishDir>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Clockify.Net" Version="2.3.0" />
+    <PackageReference Include="ClockifyClient" Version="1.0.2" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Clockify/ClockifyContext.cs
+++ b/Clockify/ClockifyContext.cs
@@ -1,33 +1,33 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
-using Clockify.Net;
-using Clockify.Net.Models.Projects;
-using Clockify.Net.Models.Tasks;
-using Clockify.Net.Models.TimeEntries;
-using Clockify.Net.Models.Users;
-using Clockify.Net.Models.Workspaces;
+using ClockifyClient;
+using ClockifyClient.Models;
+using Microsoft.Kiota.Abstractions;
 
 namespace Clockify;
 
 public class ClockifyContext
 {
+    private const int MaxPageSize = 5000;
+
     private readonly Logger _logger;
 
     private string _apiKey = string.Empty;
     private bool _billable = true;
     private string _clientName = string.Empty;
 
-    private ClockifyClient _clockifyClient;
-    private CurrentUserDto _currentUser = new();
+    private ClockifyApiClient _clockifyClient;
+    private UserDtoV1 _currentUser = new();
     private string _projectName = string.Empty;
     private string _serverUrl = string.Empty;
     private string _tags = string.Empty;
     private string _taskName = string.Empty;
     private string _timerName = string.Empty;
     private string _workspaceName = string.Empty;
-    private List<WorkspaceDto> _workspaces = new();
+    private List<WorkspaceDtoV1> _workspaces = new();
 
     public ClockifyContext(Logger logger)
     {
@@ -65,10 +65,8 @@ public class ClockifyContext
 
         var tags = await FindMatchingTagsAsync(workspace.Id, _tags);
 
-        var timeEntryRequest = new TimeEntryRequest
+        var timeEntryRequest = new CreateTimeEntryRequest
         {
-            UserId = _currentUser.Id,
-            WorkspaceId = workspace.Id,
             Description = _timerName ?? string.Empty,
             Start = DateTimeOffset.UtcNow,
             TagIds = tags,
@@ -97,18 +95,20 @@ public class ClockifyContext
             }
         }
 
-        var timeEntry = await _clockifyClient.CreateTimeEntryAsync(workspace.Id, timeEntryRequest);
-
-        if (!timeEntry.IsSuccessful || timeEntry.Data == null)
+        try
         {
-            _logger.LogError($"TimeEntry creation failed: {timeEntry.ErrorMessage}");
+            await _clockifyClient.V1.Workspaces[workspace.Id].TimeEntries.PostAsync(timeEntryRequest);
+            _logger.LogInfo($"Toggle Timer {_workspaceName}, {_projectName}, {_taskName}, {_timerName}");
+            return true;
         }
-
-        _logger.LogInfo($"Toggle Timer {_workspaceName}, {_projectName}, {_taskName}, {_timerName}");
-        return true;
+        catch (ApiException exception)
+        {
+            _logger.LogError($"TimeEntry creation failed: {exception.Message}");
+            return false;
+        }
     }
 
-    public async Task<TimeEntryDtoImpl> GetRunningTimerAsync()
+    public async Task<TimeEntryWithRatesDtoV1> GetRunningTimerAsync()
     {
         if (_clockifyClient is null || string.IsNullOrWhiteSpace(_workspaceName))
         {
@@ -122,37 +122,42 @@ public class ClockifyContext
             return null;
         }
 
-        var timeEntries =
-            await _clockifyClient.FindAllTimeEntriesForUserAsync(workspace.Id, _currentUser.Id, inProgress: true);
-        if (!timeEntries.IsSuccessful || timeEntries.Data is null)
+        try
+        {
+            var timeEntries = await _clockifyClient.V1.Workspaces[workspace.Id].User[_currentUser.Id].TimeEntries
+                .GetAsync(p => p.QueryParameters.InProgress = true);
+            
+            if (string.IsNullOrEmpty(_projectName))
+            {
+                return timeEntries.FirstOrDefault(t => string.IsNullOrEmpty(_timerName) || t.Description == _timerName);
+            }
+            
+            var project = await FindMatchingProjectAsync(workspace.Id);
+
+            if (project is null)
+            {
+                return null;
+            }
+
+            var task = await FindMatchingTaskAsync(workspace.Id, project.Id, _taskName);
+
+            var tags = await FindMatchingTagsAsync(workspace.Id, _tags);
+
+            return timeEntries.FirstOrDefault(t => t.ProjectId == project.Id
+                                                   && (string.IsNullOrEmpty(_timerName) || t.Description == _timerName)
+                                                   && (string.IsNullOrEmpty(_taskName) || string.IsNullOrEmpty(task) ||
+                                                       t.TaskId == task)
+                                                   && t.TagIds.OrderBy(s => s, StringComparer.InvariantCulture)
+                                                       .SequenceEqual(tags.OrderBy(s => s, StringComparer.InvariantCulture))
+                                                   && t.Billable == _billable);
+        }
+        catch (Exception exception) when ( exception is ApiException or HttpRequestException)
         {
             return null;
         }
-
-        if (string.IsNullOrEmpty(_projectName))
-        {
-            return timeEntries.Data.FirstOrDefault(t => string.IsNullOrEmpty(_timerName) || t.Description == _timerName);
-        }
-
-        var project = await FindMatchingProjectAsync(workspace.Id);
-
-        if (project is null)
-        {
-            return null;
-        }
-
-        var task = await FindMatchingTaskAsync(workspace.Id, project.Id, _taskName);
-
-        var tags = await FindMatchingTagsAsync(workspace.Id, _tags);
-
-        return timeEntries.Data.FirstOrDefault(t => t.ProjectId == project.Id
-                                                    && (string.IsNullOrEmpty(_timerName) || t.Description == _timerName)
-                                                    && (string.IsNullOrEmpty(_taskName) || string.IsNullOrEmpty(task) || t.TaskId == task)
-                                                    && t.TagIds.OrderBy(s => s, StringComparer.InvariantCulture).SequenceEqual(tags.OrderBy(s => s, StringComparer.InvariantCulture))
-                                                    && t.Billable == _billable);
     }
 
-    public async Task UpdateSettings(PluginSettings settings)
+    public async Task UpdateSettingsAsync(PluginSettings settings)
     {
         if (_clockifyClient == null || settings.ApiKey != _apiKey || settings.ServerUrl != _serverUrl)
         {
@@ -171,13 +176,13 @@ public class ClockifyContext
             _serverUrl = settings.ServerUrl;
             _apiKey = settings.ApiKey;
 
-            _clockifyClient = new ClockifyClient(_apiKey, settings.ServerUrl);
+            _clockifyClient = ClockifyApiClientFactory.Create(_apiKey, settings.ServerUrl);
 
             if (!await TestConnectionAsync())
             {
                 _logger.LogWarn("Invalid server URL or API key");
                 _clockifyClient = null;
-                _currentUser = new CurrentUserDto();
+                _currentUser = new UserDtoV1();
                 return;
             }
 
@@ -200,14 +205,15 @@ public class ClockifyContext
 
     private async Task ReloadCacheAsync()
     {
-        var workspaces = await _clockifyClient.GetWorkspacesAsync();
-        if (!workspaces.IsSuccessful || workspaces.Data is null)
+        try
         {
-            _logger.LogWarn($"Unable to retrieve available workspaces: {workspaces.ErrorMessage}");
-            return;
+            var workspaces = await _clockifyClient.V1.Workspaces.GetAsync();
+            _workspaces = workspaces;
         }
-
-        _workspaces = workspaces.Data;
+        catch (ApiException exception)
+        {
+            _logger.LogWarn($"Unable to retrieve available workspaces: {exception.Message}");
+        }
     }
 
     private async Task StopRunningTimerAsync()
@@ -240,48 +246,99 @@ public class ClockifyContext
             TagIds = runningTimer.TagIds
         };
 
-        await _clockifyClient.UpdateTimeEntryAsync(workspace.Id, runningTimer.Id, timerUpdate);
-        _logger.LogInfo($"Timer Stopped {_workspaceName}, {runningTimer.ProjectId}, {runningTimer.TaskId}, {runningTimer.Description}");
+        try
+        {
+            await _clockifyClient.V1.Workspaces[workspace.Id].TimeEntries[runningTimer.Id].PutAsync(timerUpdate);
+            _logger.LogInfo($"Timer Stopped {_workspaceName}, {runningTimer.ProjectId}, {runningTimer.TaskId}, {runningTimer.Description}");
+        }
+        catch (ApiException exception)
+        {
+            _logger.LogWarn($"Failed to stop running timer {_workspaceName}, {runningTimer.ProjectId}, {runningTimer.TaskId}, {runningTimer.Description}: {exception.Message}");
+        }
     }
 
-    private async Task<ProjectDtoImpl> FindMatchingProjectAsync(string workspaceId)
+    private async Task<ProjectDtoV1> FindMatchingProjectAsync(string workspaceId)
     {
-        var projects = await _clockifyClient.FindAllProjectsOnWorkspaceAsync(workspaceId, false, _projectName, pageSize: 5000);
-        if (!projects.IsSuccessful || projects.Data is null)
+        try
         {
-            _logger.LogWarn($"Unable to retrieve project {_projectName} on workspace {_workspaceName}: {projects.ErrorMessage}");
+            string clientId = null;
+
+            if (!string.IsNullOrWhiteSpace(_clientName))
+            {
+                clientId = await FindMatchingClientAsync(workspaceId, _clientName);
+            }
+
+            var projects = await _clockifyClient.V1.Workspaces[workspaceId].Projects
+                .GetAsync(q =>
+                {
+                    q.QueryParameters.Name = _projectName;
+                    q.QueryParameters.StrictNameSearch = "true";
+                    q.QueryParameters.PageSize = MaxPageSize.ToString();
+
+                    if (clientId is not null)
+                    {
+                        q.QueryParameters.Clients = clientId;
+                    }
+                });
+
+            if (projects.Count > 1)
+            {
+                _logger.LogWarn($"Multiple projects with the name {_projectName} on workspace {_workspaceName}, consider setting a client name");
+                return null;
+            }
+
+            if (!projects.Any())
+            {
+                _logger.LogWarn($"Unable to find project {_projectName} on workspace {_workspaceName} for client {_clientName}");
+                return null;
+            }
+
+            return projects.Single();
+        }
+        catch (ApiException exception)
+        {
+            _logger.LogWarn($"Unable to retrieve project {_projectName} on workspace {_workspaceName}: {exception.Message}");
             return null;
         }
+    }
 
-        var project = projects.Data
-                              .Where(p => p.Name == _projectName && (string.IsNullOrWhiteSpace(_clientName) || p.ClientName == _clientName))
-                              .ToList();
-
-        if (project.Count > 1)
+    private async Task<string> FindMatchingClientAsync(string workspaceId, string clientName)
+    {
+        try
         {
-            _logger.LogWarn($"Multiple projects with the name {_projectName} on workspace {_workspaceName}, consider setting a client name");
+            var clientResponse = await _clockifyClient.V1.Workspaces[workspaceId].Clients
+                .GetAsync(q =>
+                {
+                    q.QueryParameters.Name = clientName;
+                    q.QueryParameters.PageSize = MaxPageSize.ToString();
+                });
+            
+            return clientResponse.FirstOrDefault()?.Id;
+        }
+        catch (ApiException)
+        {
             return null;
         }
-
-        if (!project.Any())
-        {
-            _logger.LogWarn($"Unable to find project {_projectName} on workspace {_workspaceName} for client {_clientName}");
-            return null;
-        }
-
-        return project.Single();
     }
 
     private async Task<string> FindMatchingTaskAsync(string workspaceId, string projectId, string taskName)
     {
-        var taskResponse = await _clockifyClient.FindAllTasksAsync(workspaceId, projectId, name: taskName, pageSize: 5000);
+        try
+        {
+            var taskResponse = await _clockifyClient.V1.Workspaces[workspaceId].Projects[projectId].Tasks
+                .GetAsync(q =>
+                {
+                    q.QueryParameters.Name = taskName;
+                    q.QueryParameters.StrictNameSearch = "true";
+                    q.QueryParameters.PageSize = MaxPageSize.ToString();
+                });
 
-        if (!taskResponse.IsSuccessful || taskResponse.Data == null || !taskResponse.Data.Any())
+            return taskResponse.FirstOrDefault()?.Id;
+        }
+        catch (ApiException)
         {
             return null;
         }
-
-        return taskResponse.Data.First().Id;
     }
 
     private async Task<string> FindOrCreateTaskAsync(string workspaceId, string projectId, string taskName)
@@ -293,41 +350,44 @@ public class ClockifyContext
             return task;
         }
 
-        var taskRequest = new TaskRequest
+        var taskRequest = new TaskRequestV1
         {
             Name = taskName
         };
 
-        var creationResponse = await _clockifyClient.CreateTaskAsync(workspaceId, projectId, taskRequest);
-
-        if (!creationResponse.IsSuccessful || creationResponse.Data == null)
+        try
+        {
+            var creationResponse = await _clockifyClient.V1.Workspaces[workspaceId].Projects[projectId].Tasks.PostAsync(taskRequest);
+            return creationResponse.Id;
+        }
+        catch (ApiException)
         {
             return null;
         }
-
-        return creationResponse.Data.Id;
     }
 
     private async Task<List<string>> FindMatchingTagsAsync(string workspaceId, string tags)
     {
         var tagList = tags.Replace("\\,", "█")
-                          .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                          .Select(t => t.Replace("█", ","))
-                          .ToArray();
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(t => t.Replace("█", ","))
+            .ToArray();
 
         if (tagList.Length == 0)
         {
             return new List<string>();
         }
 
-        var tagsOnWorkspace = await _clockifyClient.FindAllTagsOnWorkspaceAsync(workspaceId);
-
-        if (!tagsOnWorkspace.IsSuccessful || tagsOnWorkspace.Data == null)
+        try
+        {
+            var tagsOnWorkspace = await _clockifyClient.V1.Workspaces[workspaceId].Tags
+                .GetAsync(q => q.QueryParameters.PageSize = MaxPageSize.ToString());
+            return tagsOnWorkspace.Where(t => tagList.Contains(t.Name)).Select(t => t.Id).ToList();
+        }
+        catch (ApiException)
         {
             return new List<string>();
         }
-
-        return tagsOnWorkspace.Data.Where(t => tagList.Contains(t.Name)).Select(t => t.Id).ToList();
     }
 
     private async Task<bool> TestConnectionAsync()
@@ -337,13 +397,17 @@ public class ClockifyContext
             return false;
         }
 
-        var user = await _clockifyClient.GetCurrentUserAsync();
-        if (!user.IsSuccessful || user.Data is null)
+        try
         {
+            var user = await _clockifyClient.V1.User.GetAsync();
+            _currentUser = user;
+
+            return true;
+        }
+        catch (Exception exception) when ( exception is ApiException or HttpRequestException)
+        {
+            _logger.LogDebug($"Connection test failed for: {exception.Message}");
             return false;
         }
-
-        _currentUser = user.Data;
-        return true;
     }
 }

--- a/Clockify/PluginSettings.cs
+++ b/Clockify/PluginSettings.cs
@@ -32,7 +32,7 @@ public class PluginSettings
     public string TitleFormat { get; set; } = string.Empty;
 
     [JsonProperty(PropertyName = "serverUrl")]
-    public string ServerUrl { get; set; } = "https://api.clockify.me/api/v1";
+    public string ServerUrl { get; set; } = "https://api.clockify.me/api";
 
     public override string ToString()
     {

--- a/Clockify/ToggleAction.cs
+++ b/Clockify/ToggleAction.cs
@@ -55,7 +55,8 @@ public class ToggleAction : KeypadBase
     {
         if (!_clockifyContext.IsValid())
         {
-            await _clockifyContext.UpdateSettings(_settings);
+            MigrateOldServerUrl();
+            await _clockifyContext.UpdateSettingsAsync(_settings);
             return;
         }
 
@@ -98,8 +99,9 @@ public class ToggleAction : KeypadBase
     public override async void ReceivedSettings(ReceivedSettingsPayload payload)
     {
         Tools.AutoPopulateSettings(_settings, payload.Settings);
+        MigrateOldServerUrl();
         _logger.LogDebug($"Settings Received: {_settings}");
-        await _clockifyContext.UpdateSettings(_settings);
+        await _clockifyContext.UpdateSettingsAsync(_settings);
     }
 
     public override void ReceivedGlobalSettings(ReceivedGlobalSettingsPayload payload)
@@ -138,5 +140,11 @@ public class ToggleAction : KeypadBase
         }
 
         return timerText;
+    }
+
+    // ClockifyClient expects the server URL to end with "/api" instead of "/api/v1"
+    private void MigrateOldServerUrl()
+    {
+        _settings.ServerUrl = _settings.ServerUrl.Replace("/api/v1", "/api");
     }
 }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Until the plugin is available in the [Stream Deck Store](https://apps.elgato.com
       - `{clientName}` : The client name
       - `{timer}` : The current timer value when running. Blank when not running
   - **Server Url:** *(required)* Change from the *default* URL to the API URL of your own/company instance
+    - Note: Starting with V1.11 the URL should *not* end with `/v1` 
 
 https://user-images.githubusercontent.com/920861/132741561-6f9f3ff0-a920-408d-8279-579840ce0a6b.mp4
 


### PR DESCRIPTION
As the currently used [Clockify.Net library doesn't support paging tags](https://github.com/astro-panda/Clockify.Net/issues/109) and [I wanted to play with API client generators](https://duerrenberger.dev/blog/2025/07/10/using-openapi-client-generators/), I've created [a new API client](https://github.com/eXpl0it3r/ClockifyClient) based on the OpenAPI spec.

This PR switches from Clockify.Net to ClockifyClient and fixes #33 as the tag endpoint now supports paging.