### PR TITLE
Update Dependencies & update to .NET 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,16 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: MacOS, os: macos-14, rid: osx-x64 }
-        - { name: Windows VS2022, os: windows-2022, rid: win-x64 }
+        - { name: MacOS, os: macos-15, rid: osx-x64 }
+        - { name: Windows, os: windows-2025, rid: win-x64 }
         dotnet:
-        - { name: .NET 6, version: '6.0.x' }
+        - { name: .NET 8, version: '8.0.x' }
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup .NET ${{ matrix.dotnet.version }} SDK
         id: setup-dotnet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ matrix.dotnet.version }}
       - name: Enforce SDK Version
@@ -35,27 +35,27 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
       - name: Publish
-        run: dotnet publish --runtime ${{ matrix.platform.rid }} --self-contained --configuration Release -p:PublishReadyToRun=true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:IncludeNativeLibrariesForSelfExtract=true
+        run: dotnet publish --runtime ${{ matrix.platform.rid }} --self-contained --configuration Release -p:PublishReadyToRun=true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:TrimMode=partial -p:IncludeNativeLibrariesForSelfExtract=true
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: clockify-${{ matrix.platform.os }}
           path: bin/Publish/dev.duerrenberger.clockify.sdPlugin
   package:
     name: Package Builds
-    runs-on: macos-14
+    runs-on: macos-15
     needs: build
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
       - name: Clean Up Artifacts
         shell: bash
         run: |
           mkdir $GITHUB_WORKSPACE/dev.duerrenberger.clockify.sdPlugin
           mkdir $GITHUB_WORKSPACE/dev.duerrenberger.clockify.sdPlugin/Windows
           mkdir $GITHUB_WORKSPACE/dev.duerrenberger.clockify.sdPlugin/macOS
-          mv $GITHUB_WORKSPACE/clockify-windows-2022/* $GITHUB_WORKSPACE/dev.duerrenberger.clockify.sdPlugin/Windows/
-          mv $GITHUB_WORKSPACE/clockify-macos-14/* $GITHUB_WORKSPACE/dev.duerrenberger.clockify.sdPlugin/macOS/
+          mv $GITHUB_WORKSPACE/clockify-windows-2025/* $GITHUB_WORKSPACE/dev.duerrenberger.clockify.sdPlugin/Windows/
+          mv $GITHUB_WORKSPACE/clockify-macos-15/* $GITHUB_WORKSPACE/dev.duerrenberger.clockify.sdPlugin/macOS/
           mv $GITHUB_WORKSPACE/dev.duerrenberger.clockify.sdPlugin/Windows/Images/ $GITHUB_WORKSPACE/dev.duerrenberger.clockify.sdPlugin/
           mv $GITHUB_WORKSPACE/dev.duerrenberger.clockify.sdPlugin/Windows/PropertyInspector/ $GITHUB_WORKSPACE/dev.duerrenberger.clockify.sdPlugin/
           mv $GITHUB_WORKSPACE/dev.duerrenberger.clockify.sdPlugin/Windows/manifest.json $GITHUB_WORKSPACE/dev.duerrenberger.clockify.sdPlugin/
@@ -69,7 +69,7 @@ jobs:
           input-directory: "/dev.duerrenberger.clockify.sdPlugin"
           output-directory: "/publish"
       - name: Upload StreamDeck App
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dev.duerrenberger.clockify.streamDeckPlugin
           path: publish/dev.duerrenberger.clockify.streamDeckPlugin

--- a/Clockify.csproj
+++ b/Clockify.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <UseWindowsForms>false</UseWindowsForms>
-    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <AssemblyName>dev.duerrenberger.clockify</AssemblyName>
     <OutputType>Exe</OutputType>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -20,8 +21,8 @@
     <PackageIconUrl>https://github.com/eXpl0it3r/streamdeck-clockify/blob/master/Images/clockifyIcon%402x.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/eXpl0it3r/streamdeck-clockify</RepositoryUrl>
     <RootNamespace />
-    <TargetFramework>net6.0-windows</TargetFramework>
-    <LangVersion>10</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>bin\Debug\dev.duerrenberger.clockify.sdPlugin\</OutputPath>
@@ -42,9 +43,11 @@
     </PackageReference>
     <PackageReference Include="NLog" Version="5.5.1" />
     <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="6.0.5.128" />
-    <PackageReference Include="streamdeck-client-csharp" Version="4.3.0" />
-    <PackageReference Include="StreamDeck-Tools" Version="6.2.0" />
+    <PackageReference Include="StreamDeck-Tools" Version="6.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <!-- Satisfy dependency resolution for StreamDeck-Tools -->
+    <PackageReference Include="System.Collections.Immutable" Version="9.0.10" />
+    <PackageReference Include="System.Reflection.Metadata" Version="9.0.10" />
   </ItemGroup>
   <ItemGroup>
     <None Update="manifest.json">

--- a/Clockify.csproj
+++ b/Clockify.csproj
@@ -34,7 +34,7 @@
     <PublishDir>bin\Publish\dev.duerrenberger.clockify.sdPlugin\</PublishDir>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ClockifyClient" Version="1.0.3" />
+    <PackageReference Include="ClockifyClient" Version="1.1.1" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
@@ -44,7 +44,7 @@
     <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="6.0.5.128" />
     <PackageReference Include="streamdeck-client-csharp" Version="4.3.0" />
     <PackageReference Include="StreamDeck-Tools" Version="6.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
   <ItemGroup>
     <None Update="manifest.json">

--- a/Clockify.csproj
+++ b/Clockify.csproj
@@ -10,8 +10,8 @@
     <StartupObject>Clockify.Program</StartupObject>
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    <AssemblyVersion>1.11</AssemblyVersion>
-    <PackageVersion>1.11</PackageVersion>
+    <AssemblyVersion>1.12</AssemblyVersion>
+    <PackageVersion>1.12</PackageVersion>
     <Title>Clockify</Title>
     <Authors>Lukas Dürrenberger</Authors>
     <Description>This plugin allows you to track, start and stop Clockify timers on your Elgato Stream Deck</Description>

--- a/Clockify/ClockifyContext.cs
+++ b/Clockify/ClockifyContext.cs
@@ -271,12 +271,12 @@ public class ClockifyContext
                 .GetAsync(q =>
                 {
                     q.QueryParameters.Name = _projectName;
-                    q.QueryParameters.StrictNameSearch = "true";
-                    q.QueryParameters.PageSize = MaxPageSize.ToString();
+                    q.QueryParameters.StrictNameSearch = true;
+                    q.QueryParameters.PageSize = MaxPageSize;
 
                     if (clientId is not null)
                     {
-                        q.QueryParameters.Clients = clientId;
+                        q.QueryParameters.Clients = new []{ clientId };
                     }
                 });
 
@@ -309,7 +309,7 @@ public class ClockifyContext
                 .GetAsync(q =>
                 {
                     q.QueryParameters.Name = clientName;
-                    q.QueryParameters.PageSize = MaxPageSize.ToString();
+                    q.QueryParameters.PageSize = MaxPageSize;
                 });
             
             return clientResponse.FirstOrDefault()?.Id;
@@ -328,8 +328,8 @@ public class ClockifyContext
                 .GetAsync(q =>
                 {
                     q.QueryParameters.Name = taskName;
-                    q.QueryParameters.StrictNameSearch = "true";
-                    q.QueryParameters.PageSize = MaxPageSize.ToString();
+                    q.QueryParameters.StrictNameSearch = true;
+                    q.QueryParameters.PageSize = MaxPageSize;
                 });
 
             return taskResponse.FirstOrDefault()?.Id;
@@ -380,7 +380,7 @@ public class ClockifyContext
         try
         {
             var tagsOnWorkspace = await _clockifyClient.V1.Workspaces[workspaceId].Tags
-                .GetAsync(q => q.QueryParameters.PageSize = MaxPageSize.ToString());
+                .GetAsync(q => q.QueryParameters.PageSize = MaxPageSize);
             return tagsOnWorkspace.Where(t => tagList.Contains(t.Name)).Select(t => t.Id).ToList();
         }
         catch (ApiException)

--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,7 @@
   "Description": "Stream Deck integration for Clockify, the most popular free time tracker available for an unlimited numbers of users for free.",
   "Icon": "Images/clockifyIcon",
   "URL": "https://duerrenberger.dev",
-  "Version": "1.11",
+  "Version": "1.12",
   "CodePathWin": "Windows/dev.duerrenberger.clockify.exe",
   "CodePathMac": "macOS/dev.duerrenberger.clockify",
   "Category": "Time Tracking",


### PR DESCRIPTION
Update

- ClockifyClient
- StreamDeck-Tools
- Newtonsoft.Json

Update to .NET 8 and only do partial trimming to prevent the removal of dynamically used class constructors/methods